### PR TITLE
Add semantic versioning using Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            Chirp.CLI-${{tag}}-linux-x64.zip
-            Chirp.CLI-${{tag}}-windows-x64.zip
-            Chirp.CLI-${{tag}}-osx-x64.zip
-            Chirp.CLI-${{tag}}-osx-arm-x64.zip
+            Chirp.CLI-${tag}-linux-x64.zip
+            Chirp.CLI-${tag}-windows-x64.zip
+            Chirp.CLI-${tag}-osx-x64.zip
+            Chirp.CLI-${tag}-osx-arm-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,22 @@ jobs:
         run: |
           dotnet publish -c Release -r linux-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Release/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Release/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create Windows Release
         run: |
           dotnet publish -c Release -r win-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Release/net7.0/win-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Release/net7.0/win-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create OSX x64 Release
         run: |
           dotnet publish -c Release -r osx-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create OSX arm Release
         run: |
           dotnet publish -c Release -r osx-arm64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-arm64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-arm64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - $default-branch
+      - feat-add_semantic_versioning
     tags:
       - v*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,29 +37,33 @@ jobs:
 
       - name: Create Linux Release
         run: |
+          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r linux-x64 --self-contained
-          zip -r linux-x64.zip src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
 
+          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create Windows Release
         run: |
-          dotnet publish -r win-x64 --self-contained
-          zip -r win-x64.zip src/Chirp.CLI/bin/Debug/net7.0/win-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/win-x64/publish/
+          tag=$(git describe --tags --abbrev=0)
+          dotnet publish -r windows-x64 --self-contained
 
+          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX x64 Release
         run: |
+          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r osx-x64 --self-contained
-          zip -r osx-x64.zip src/Chirp.CLI/bin/Debug/net7.0/osx-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/osx-x64/publish/
 
+          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX arm Release
         run: |
-          dotnet publish -r osx-arm64 --self-contained
-          zip -r osx-arm64.zip src/Chirp.CLI/bin/Debug/net7.0/osx-arm64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/osx-arm64/publish/
+          tag=$(git describe --tags --abbrev=0)
+          dotnet publish -r osx-arm-x64 --self-contained
 
+          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            linux-x64.zip
-            win-x64.zip
-            osx-x64.zip
-            osx-arm64.zip
+            "Chirp.CLI-$tag-linux-x64.zip"
+            "Chirp.CLI-$tag-windows-x64.zip"
+            "Chirp.CLI-$tag-osx-x64.zip"
+            "Chirp.CLI-$tag-osx-arm-x64.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,24 +42,24 @@ jobs:
 
       - name: Create Linux Release
         run: |
-          dotnet publish -r linux-x64 --self-contained false
+          dotnet publish -c Release -r linux-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
+          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Release/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
       - name: Create Windows Release
         run: |
-          dotnet publish -r win-x64 --self-contained false
+          dotnet publish -c Release -r win-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
+          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Release/net7.0/win-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
       - name: Create OSX x64 Release
         run: |
-          dotnet publish -r osx-x64 --self-contained false
+          dotnet publish -c Release -r osx-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
+          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
       - name: Create OSX arm Release
         run: |
-          dotnet publish -r osx-arm64 --self-contained false
+          dotnet publish -c Release -r osx-arm64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
+          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-arm64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" -x "*.pdb"
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,22 +42,22 @@ jobs:
 
       - name: Create Linux Release
         run: |
-          dotnet publish -r linux-x64 --self-contained
+          dotnet publish -r linux-x64 --self-contained false
 
           zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create Windows Release
         run: |
-          dotnet publish -r win-x64 --self-contained
+          dotnet publish -r win-x64 --self-contained false
 
           zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX x64 Release
         run: |
-          dotnet publish -r osx-x64 --self-contained
+          dotnet publish -r osx-x64 --self-contained false
 
           zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX arm Release
         run: |
-          dotnet publish -r osx-arm64 --self-contained
+          dotnet publish -r osx-arm64 --self-contained false
 
           zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Upload Release Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            "Chirp.CLI-$tag-linux-x64.zip"
-            "Chirp.CLI-$tag-windows-x64.zip"
-            "Chirp.CLI-$tag-osx-x64.zip"
-            "Chirp.CLI-$tag-osx-arm-x64.zip"
+            Chirp.CLI-$tag-linux-x64.zip
+            Chirp.CLI-$tag-windows-x64.zip
+            Chirp.CLI-$tag-osx-x64.zip
+            Chirp.CLI-$tag-osx-arm-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,10 @@ jobs:
           zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
+        run: tag=$(git describe --tags --abbrev=0)
         with:
           files: |
-            Chirp.CLI-$tag-linux-x64.zip
-            Chirp.CLI-$tag-windows-x64.zip
-            Chirp.CLI-$tag-osx-x64.zip
-            Chirp.CLI-$tag-osx-arm-x64.zip
+            Chirp.CLI-${tag}-linux-x64.zip
+            Chirp.CLI-${tag}-windows-x64.zip
+            Chirp.CLI-${tag}-osx-x64.zip
+            Chirp.CLI-${tag}-osx-arm-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set tag
-        run: |
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+      - name: Set tag
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
-
+  
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create OSX arm Release
         run: |
           tag=$(git describe --tags --abbrev=0)
-          dotnet publish -r osx-arm-x64 --self-contained
+          dotnet publish -r osx-arm64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Upload Release Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set tag
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -40,25 +43,21 @@ jobs:
 
       - name: Create Linux Release
         run: |
-          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r linux-x64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create Windows Release
         run: |
-          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r win-x64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX x64 Release
         run: |
-          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r osx-x64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX arm Release
         run: |
-          tag=$(git describe --tags --abbrev=0)
           dotnet publish -r osx-arm64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
@@ -66,7 +65,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            Chirp.CLI-${tag}-linux-x64.zip
-            Chirp.CLI-${tag}-windows-x64.zip
-            Chirp.CLI-${tag}-osx-x64.zip
-            Chirp.CLI-${tag}-osx-arm-x64.zip
+            Chirp.CLI-${{ env.tag }}-linux-x64.zip
+            Chirp.CLI-${{ env.tag }}-windows-x64.zip
+            Chirp.CLI-${{ env.tag }}-osx-x64.zip
+            Chirp.CLI-${{ env.tag }}-osx-arm-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,9 @@ jobs:
           zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
-        run: tag=$(git describe --tags --abbrev=0)
         with:
           files: |
-            Chirp.CLI-${tag}-linux-x64.zip
-            Chirp.CLI-${tag}-windows-x64.zip
-            Chirp.CLI-${tag}-osx-x64.zip
-            Chirp.CLI-${tag}-osx-arm-x64.zip
+            Chirp.CLI-${{tag}}-linux-x64.zip
+            Chirp.CLI-${{tag}}-windows-x64.zip
+            Chirp.CLI-${{tag}}-osx-x64.zip
+            Chirp.CLI-${{tag}}-osx-arm-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,22 @@ jobs:
         run: |
           dotnet publish -r linux-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
+          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
       - name: Create Windows Release
         run: |
           dotnet publish -r win-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
+          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
       - name: Create OSX x64 Release
         run: |
           dotnet publish -r osx-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
+          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
       - name: Create OSX arm Release
         run: |
           dotnet publish -r osx-arm64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
+          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln"
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,22 @@ jobs:
         run: |
           dotnet publish -c Release -r linux-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Release/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-linux-x64.zip" src/Chirp.CLI/bin/Release/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create Windows Release
         run: |
           dotnet publish -c Release -r win-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Release/net7.0/win-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Release/net7.0/win-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create OSX x64 Release
         run: |
           dotnet publish -c Release -r osx-x64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-osx-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-x64/publish/ -x "*.sln" "*.pdb"
       - name: Create OSX arm Release
         run: |
           dotnet publish -c Release -r osx-arm64 --self-contained false
 
-          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-arm64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/ -x "*.sln" "*.pdb"
+          zip -r -j "Chirp.CLI-$tag-osx-arm-x64.zip" src/Chirp.CLI/bin/Release/net7.0/osx-arm64/publish/ -x "*.sln" "*.pdb"
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Create Windows Release
         run: |
           tag=$(git describe --tags --abbrev=0)
-          dotnet publish -r windows-x64 --self-contained
+          dotnet publish -r win-x64 --self-contained
 
           zip -r -j "Chirp.CLI-$tag-windows-x64.zip" src/Chirp.CLI/bin/Debug/net7.0/linux-x64/publish/ src/Chirp.SimpleDB/bin/Debug/net7.0/linux-x64/publish/
       - name: Create OSX x64 Release

--- a/src/Chirp.CLI/Chirp.CLI.csproj
+++ b/src/Chirp.CLI/Chirp.CLI.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net7.0</TargetFramework>
+        <PublishSingleFile>true</PublishSingleFile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -20,7 +21,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Chirp.SimpleDB\Chirp.SimpleDB.csproj" />
-    </ItemGroup>
+  </ItemGroup>
 
 
 


### PR DESCRIPTION
The following is a pull request for adding a Github Action, which will use `git tag` to create releases with appropriate versioning using semantic versioning. For this to work, when pushing to main, make sure to have set a `git tag`. 

If unsure how this work read: [Git Basics Tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging)