### PR TITLE
Added SeedDatabase to db context

### DIFF
--- a/src/Chirp.Razor/Program.cs
+++ b/src/Chirp.Razor/Program.cs
@@ -17,7 +17,6 @@ builder.Services
     .AddScoped<ICheepService, CheepService>()
 ;
 
-
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -30,8 +29,14 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
-
 app.UseRouting();
+
+// Get an instance of ChirpDBContext
+var context = app.Services.CreateScope().ServiceProvider.GetRequiredService<ChirpDBContext>();
+
+// Add template data to the database
+DbInitializer.SeedDatabase(context);
+context.Database.EnsureCreated();
 
 app.MapRazorPages();
 


### PR DESCRIPTION
- This seems to fix the error of too many redirects.

Explanation:
The .SeedDatabase method was removed in a previous commit. The reason the website was redirecting indefinitely was because the data was not being loaded into the database. This commit fixes this issue, but instead of adding data in the constructor of the ChirpStorage class, which would make it hard to test said class, the database is seeded directly in the program.cs file. If you can think of a cleaner or more correct solution, do let me know!