### PR TITLE
Refactor CheepRepository and ChirpModel

### DIFF
--- a/src/Chirp.Core/Repositories/ICheepRepository.cs
+++ b/src/Chirp.Core/Repositories/ICheepRepository.cs
@@ -2,10 +2,14 @@ namespace Chirp.Core;
 
 public interface ICheepRepository
 {
-    public void StoreCheep(Cheep cheep);
-    public void StoreCheeps(List<Cheep> entities);
-    public IEnumerable<Cheep> QueryCheeps(int pageNumber, int amount, string? author = null, bool isAuthor = false);
-    public int QueryCheepCount(string? author = null, bool isAuthor = false);
-    public void DeleteCheep(Cheep cheep);
-    public void DeleteAllCheepsByAuthorId(int authorId) ;
+    void StoreCheep(Cheep cheep);
+    void StoreCheeps(List<Cheep> entities);
+    IEnumerable<Cheep> GetCheepsPaginated(int pageNumber, int cheepsPerPage, string? author = null, bool isUser = false);
+    IQueryable<Cheep> GetQueryableCheeps(string? author = null, bool isUser = false);
+    IQueryable<Cheep> GetAllCheepsByAuthorAndFollowers(int authorId);
+    IQueryable<Cheep> GetAll();
+    IQueryable<Cheep> GetAllCheepsByAuthorId(int authorId);
+    void DeleteAllCheepsByAuthorId(int authorId);
+    void DeleteCheep(Cheep cheep);
+    
 }

--- a/src/Chirp.Web/Pages/Models/ChirpModel.cshtml.cs
+++ b/src/Chirp.Web/Pages/Models/ChirpModel.cshtml.cs
@@ -4,9 +4,6 @@ public class ChirpModel : PageModel
 {
     protected readonly IRepositoryManager _repositoryManager;
 
-    // Can be moved to timelinemodel once cheeprepository is fixed
-    public int CheepsPerPage => 32;
-
     public ChirpModel(IRepositoryManager repositoryManager)
     {
         _repositoryManager = repositoryManager;

--- a/src/Chirp.Web/Pages/Models/TimelineModel.cshtml.cs
+++ b/src/Chirp.Web/Pages/Models/TimelineModel.cshtml.cs
@@ -5,8 +5,10 @@ public class TimelineModel : ChirpModel
     public string RouteName = "";
     public List<Cheep> Cheeps { get; set; } = new List<Cheep>();
     public int NumOfCheeps;
+    public int CheepsPerPage = 32;
     public int CurrentPage = 1;
     public int MaxCharacterCount = 160;
+    
     public TimelineModel(IRepositoryManager repositoryManager)
         : base(repositoryManager) { }
 
@@ -99,7 +101,7 @@ public class TimelineModel : ChirpModel
     {
         RouteName = HttpContext.GetRouteValue("author")?.ToString() ?? "";
         var isAuthor = CalculateIsAuthor(author, GetUserName());
-        NumOfCheeps = _repositoryManager.CheepRepository.QueryCheepCount(author, isAuthor);
+        NumOfCheeps = _repositoryManager.CheepRepository.GetQueryableCheeps(author, isAuthor).Count();
 
         int maxPage = (int)Math.Ceiling((double)NumOfCheeps / CheepsPerPage);
 
@@ -115,7 +117,7 @@ public class TimelineModel : ChirpModel
         }
 
         CurrentPage = page;
-        Cheeps = _repositoryManager.CheepRepository.QueryCheeps(page, CheepsPerPage, author, isAuthor).ToList();
+        Cheeps = _repositoryManager.CheepRepository.GetCheepsPaginated(page, CheepsPerPage, author, isAuthor).ToList();
         return Page();
     }
 }

--- a/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
+++ b/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
@@ -8,14 +8,14 @@ public class UserInformationModel : ChirpModel
 
     public IEnumerable<Cheep> GetCheeps(string? authorName = null){
         // This can be cleaned up by moving the pagenumber parameter to the web project
-        return _repositoryManager.CheepRepository.QueryCheeps(1, 10000, GetAuthor(authorName).Name, false).ToList();
+        return _repositoryManager.CheepRepository.GetQueryableCheeps(GetAuthor(authorName).Name).ToList();
     }
 
     public IEnumerable<Cheep> GetLikedCheeps(string? authorName = null){
         var likes = _repositoryManager.LikeRepository.FindLikesByAuthorId(GetAuthor(authorName).AuthorId);
 
         // Error-prone since it doesn't account for all pages (all cheeps)
-        return _repositoryManager.CheepRepository.QueryCheeps(1, CheepsPerPage, authorName).ToList().Where(c => likes.Any(l => l.CheepId == c.CheepId));
+        return _repositoryManager.CheepRepository.GetQueryableCheeps(authorName).Where(c => likes.Any(l => l.CheepId == c.CheepId));
     }
 
     public IActionResult OnPostDelete()

--- a/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
+++ b/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
@@ -7,7 +7,6 @@ public class UserInformationModel : ChirpModel
         : base(repositoryManager) {}
 
     public IEnumerable<Cheep> GetCheeps(string? authorName = null){
-        // This can be cleaned up by moving the pagenumber parameter to the web project
         return _repositoryManager.CheepRepository.GetQueryableCheeps(GetAuthor(authorName).Name).ToList();
     }
 

--- a/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
+++ b/src/Chirp.Web/Pages/Models/UserInformation.cshtml.cs
@@ -14,7 +14,6 @@ public class UserInformationModel : ChirpModel
     public IEnumerable<Cheep> GetLikedCheeps(string? authorName = null){
         var likes = _repositoryManager.LikeRepository.FindLikesByAuthorId(GetAuthor(authorName).AuthorId);
 
-        // Error-prone since it doesn't account for all pages (all cheeps)
         return _repositoryManager.CheepRepository.GetQueryableCheeps(authorName).Where(c => likes.Any(l => l.CheepId == c.CheepId));
     }
 

--- a/test/Chirp.Infrastructure.UnitTest/CheepRepositoryTest.cs
+++ b/test/Chirp.Infrastructure.UnitTest/CheepRepositoryTest.cs
@@ -48,7 +48,7 @@ public class CheepRepositoryTest
         context.SaveChanges();
 
         // Act
-        var count = chirpStorage.QueryCheepCount();
+        var count = chirpStorage.GetQueryableCheeps().Count();
 
         // Assert
         Assert.Equal(1, count);
@@ -113,7 +113,7 @@ public class CheepRepositoryTest
         context.SaveChanges();
 
         // Act
-        var cheeps = chirpStorage.QueryCheeps(1, 32, author: "Jens");
+        var cheeps = chirpStorage.GetQueryableCheeps(author: "Jens");
 
         // Assert
         cheeps.Count().Should().Be(2);


### PR DESCRIPTION
fixed the problem where ChirpModel couldn't get all cheeps for author without pagination.

IQueryable when used for queries later.
IEnumerable when pagination.

Refactored QueryCheep() method into smaller functions with more distinct responsibilities.

QueryCheepCount() --> GetQueryableCheeps().Count()


...We might have to bring back CheepService to separate business logic, and to prevent the repositories from being tightly coupled?